### PR TITLE
23 possibility to show relative instead of absolute departure times

### DIFF
--- a/ha-departureCard.js
+++ b/ha-departureCard.js
@@ -322,9 +322,8 @@ class DepartureCard extends HTMLElement {
                 { name: "departure", description: "Departure time attribute", selector: { text: {} } },
                 { name: "delay", selector: { text: {} } },
                 { name: "unix_time", selector: { boolean: {} } },
-                { name: "convertTimeHHMM", selector: { boolean: {} } }
+                { name: "convertTimeHHMM", selector: { boolean: {} } },
                 { name: "relativeTime", selector: { boolean: {} } }
-
               ]
             },
             {


### PR DESCRIPTION
Add selector for relative Time.
When activated all time values are presented like “in x Minuten”. If there is a delay the text is red.