### PR TITLE
Introduced display feature for "minor delays"

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ All time values above the limit will be displayed in HH:MM.
 
 Default is set to 60
 
+### minorDelayLimit
+Delays that are bigger than the value minorDelayLimit (given in minutes) are colored with error accent color. Delays up to minorDelayLimit value are highlighted in warning accent color to provide a visual differentiation.
+
+Default is set to 5
+
 ## connection_properties
 
 Defines how each departure is displayed and which properties are included.

--- a/ha-departureCard.js
+++ b/ha-departureCard.js
@@ -67,6 +67,7 @@ class DepartureCard extends HTMLElement {
     const convertTimeHHMM = config.convertTimeHHMM || false;
     const relativeTime = config.relativeTime || false;
     const limit = config.limit || 60;
+    const minorDelayLimit = config.minorDelayLimit || 5; // This is the amount of minutes that are still considered a "minor" delay with different coloring. Setting it to 0 disables this feature
 
     // Targets (destinations) that should be filtered from the connections list
     const targets = config.targets || [];
@@ -188,6 +189,9 @@ class DepartureCard extends HTMLElement {
 		  .on-time .departure {
 		    color: var(--success-color);
 		  }
+		  .minor-delayed .departure {
+		    color: var(--warning-color);
+		  }
 		  .delayed .departure {
 		    color: var(--error-color);
 		  }
@@ -224,7 +228,10 @@ class DepartureCard extends HTMLElement {
             min-width: 20px;
             white-space: nowrap;
           }
-          .delay span {
+          .minor-delayed .delayText {
+            color: var(--warning-color);
+          }
+          .delayed .delayText {
             color: var(--error-color);
           }
         </style>
@@ -257,8 +264,15 @@ class DepartureCard extends HTMLElement {
         departure = connection[config.departure] || '';
       }
 
-      // Default color for departure time and text for no delay.mIf there is a delay, adjust color and add delay text
-      let departureState = delay > 0 ? "delayed" : "on-time";
+      // Default color for departure time and text for no delay. If there is a delay, adjust color and add delay text
+      let departureState;
+      if (delay > minorDelayLimit) {
+        departureState = "delayed";
+      } else if (delay > 0) {
+        departureState = "minor-delayed";
+      } else {
+        departureState = "on-time";
+      }
       let delayText = delay > 0 ? `+${delay}` : "";
       departureState = isCancelled == 1 ? "cancelled" : departureState;
 
@@ -296,7 +310,7 @@ class DepartureCard extends HTMLElement {
             <td class="destination"><span class="destination-text">${destination}</span></td>
             ${config.show_platform ? `<td class="platform">${platform}</td>` : ""}
             <td class="departure">${departure}</td>
-            ${!relativeTime ? `<td class="delay">${delayText ? `<span>${delayText}</span>` : ""}</td>` : ""}
+            ${!relativeTime ? `<td class="delay">${delayText ? `<span class="delayText">${delayText}</span>` : ""}</td>` : ""}
           </tr>
         `;
     });
@@ -332,6 +346,7 @@ class DepartureCard extends HTMLElement {
       convertTimeHHMM: false,
       relativeTime: false,
       limit : 60,
+      minorDelayLimit: 5,
       targets: '', 
       exclude: false,
       line: '',


### PR DESCRIPTION
## Original behavior

When a delay > 0 (in minutes) is observed, formatting of the time display is changed to error-color (depending on theme, defaults to red).

## Introduced / changed behavior

### Summary

Display color of the time (and delay string) is depending on the magnitude of the delay. For smaller delays, the display color will be set to warning-color (depending on theme, defaults to yellow/orange). Only if the delay is bigger than a newly introduced limit (configurable), the delay will be formatted as usual (error-color / red).

### Implementation Details

#### New config option

Introduced config option minorDelayLimit. This controls the maximum number of minutes, that still are formatted in warning-color. Delays above this threshold will be formatted as usual (error-color).

Defaults to 5 minutes.

To fallback to original behavior, simply set to 0.

#### change in values for departureState

departureState now can hold an additional value ("minor-delayed") additionally to the existing ones ("on-time", "delayed")

#### added CSS classes

new formatting options are realized with new CSS classes .minor-delayed

