### PR TITLE
fix relative time error after midnight

### DIFF
--- a/ha-departureCard.js
+++ b/ha-departureCard.js
@@ -281,7 +281,7 @@ class DepartureCard extends HTMLElement {
           now = new Date(),
           d = new Date(now);
         d.setHours(h, m + delay, 0, 0);
-        if (d < now && d-now > 5) d.setDate(d.getDate() + 1); // Mitternacht-Übergang
+        if (d < now) d.setDate(d.getDate() + 1); // Mitternacht-Übergang
 
         let diffMinutes = Math.round((d - now) / 60000);
         if (diffMinutes < limit) {


### PR DESCRIPTION
Fixes #34 

This if-statement:
```javascript
        if (d < now && d-now > 5) d.setDate(d.getDate() + 1); // Mitternacht-Übergang
```
could never be fulfilled. If `d < now`, `d-now` is always negative and can never be greater than `5`.

I removed the second part:
```javascript
        if (d < now) d.setDate(d.getDate() + 1); // Mitternacht-Übergang
```